### PR TITLE
fix compilation on Ubuntu 22.04 with kernel version 6.2.0-33-generic

### DIFF
--- a/isfri.c
+++ b/isfri.c
@@ -54,7 +54,7 @@ static struct file_operations chardev_fops = {
 	.release = device_release,
 };
 
-static char *isfri_devnode(struct device *dev, umode_t *mode){
+static char *isfri_devnode(const struct device *dev, umode_t *mode){
 	if (mode) *mode = 0666;
 	return NULL;
 }


### PR DESCRIPTION
Error was:
  CC [M]  <...>/isfri/isfri.o
<...>/isfri/isfri.c: In function 'chardev_init':
<...>/isfri/isfri.c:86:22: error: assignment to 'char * (*)(const struct device *, umode_t *)' {aka 'char * (*)(const struct device *, short unsigned int *)'} from incompatible pointer type 'char * (*)(struct device *, umode_t *)' {aka 'char * (*)(struct device *, short unsigned int *)'} [-Werror=incompatible-pointer-types]
   86 |         cls->devnode = isfri_devnode;
      |                      ^
cc1: some warnings being treated as errors